### PR TITLE
Allow a proxy when initializing HTTPClient

### DIFF
--- a/lib/synapse_pay_rest/http_client.rb
+++ b/lib/synapse_pay_rest/http_client.rb
@@ -10,6 +10,10 @@ module SynapsePayRest
     #   @return [Hash] various settings related to request headers
     attr_accessor :base_url, :config
 
+    # @!attribute [rw] proxy_url
+    #   @return [String] the url which is used to proxy outboard requests
+    attr_reader :proxy_url
+
     # @param base_url [String] the base url of the API (production or sandbox)
     # @param client_id [String]
     # @param client_secret [String]
@@ -17,11 +21,15 @@ module SynapsePayRest
     # @param ip_address [String]
     # @param logging [Boolean] (optional) logs to stdout when true
     # @param log_to [String] (optional) file path to log to file (logging must be true)
+    # @param proxy_url [String] (optional) proxy url which is used to proxy outbound requests
     def initialize(base_url:, client_id:, fingerprint:, ip_address:,
                    client_secret:, **options)
       log_to         = options[:log_to] || 'stdout'
       RestClient.log = log_to if options[:logging]
       @logging       = options[:logging]
+
+      RestClient.proxy = options[:proxy_url] if options[:proxy_url]
+      @proxy_url = options[:proxy_url]
 
       @config = {
         client_id:     client_id,

--- a/samples.md
+++ b/samples.md
@@ -26,6 +26,8 @@ args = {
   logging:          true,
   # (optional) file path to write logs to
   log_to:           nil
+  # (optional) URL used to proxy outbound requests
+  proxy_url:        nil
 }
 
 client = SynapsePayRest::Client.new(args)

--- a/test/factories/client.rb
+++ b/test/factories/client.rb
@@ -4,7 +4,8 @@ def test_client(client_id: ENV.fetch('TEST_CLIENT_ID'),
                 ip_address: '127.0.0.1',
                 development_mode: true,
                 logging: false,
-                log_to: nil)
+                log_to: nil,
+                proxy_url: nil)
 
   SynapsePayRest::Client.new(
     client_id: client_id,
@@ -13,7 +14,8 @@ def test_client(client_id: ENV.fetch('TEST_CLIENT_ID'),
     fingerprint: fingerprint,
     ip_address: ip_address,
     logging: logging,
-    log_to: log_to
+    log_to: log_to,
+    proxy_url: proxy_url
   )
 end
 

--- a/test/synapse_pay_rest/http_client_test.rb
+++ b/test/synapse_pay_rest/http_client_test.rb
@@ -6,6 +6,10 @@ class HTTPClientTest < Minitest::Test
     @http_client = @client.http_client
   end
 
+  def teardown
+    RestClient.proxy = nil
+  end
+
   def test_base_url
     assert_respond_to @http_client, :base_url
   end
@@ -40,5 +44,17 @@ class HTTPClientTest < Minitest::Test
     assert_equal config[:client_secret], new_options[:client_secret]
     assert_equal config[:ip_address], new_options[:ip_address]
     assert_equal config[:oauth_key], new_options[:oauth_key]
+  end
+
+  def test_proxy_url
+    proxy_url = 'http://proxy.example.org:80'
+
+    client_without_proxy = test_client
+    assert_nil client_without_proxy.http_client.proxy_url
+    assert_nil RestClient.proxy
+
+    client_with_proxy = test_client(proxy_url: proxy_url)
+    assert_equal client_with_proxy.http_client.proxy_url, proxy_url
+    assert_equal RestClient.proxy, proxy_url
   end
 end


### PR DESCRIPTION
# What this PR does

Adds support for configuring `SynapsePayRest::Client` with a proxy. This is achieved by handling an optional parameter (`proxy_url`) when initializing the client. `proxy_url` is passed along to the underlying RestClient for use in routing outboard requests.

# Additional Context

Documentation for configuring a proxy with RestClient can be found: [here](https://github.com/rest-client/rest-client#proxy)